### PR TITLE
Basic python3 compatibility

### DIFF
--- a/PostProcessors/TeamAutoPkg.py
+++ b/PostProcessors/TeamAutoPkg.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 
 import subprocess

--- a/PostProcessors/TeamAutoPkg.py
+++ b/PostProcessors/TeamAutoPkg.py
@@ -15,12 +15,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
 
-import subprocess
-import os.path
-import json
 import requests
+
+from autopkglib import Processor, ProcessorError
 
 # Set the webhook_url to the one provided by Teams then you create the webhook
 
@@ -62,7 +60,7 @@ class TeamAutoPkg(Processor):
         was_imported = self.env.get("munki_repo_changed")
         munkiInfo = self.env.get("munki_info")
         webhook_url = self.env.get("webhook_url")
-        
+
 
         if was_imported:
             name = self.env.get("munki_importer_summary_result")[


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.