### PR TITLE
System Requirements Need to be Updated

### DIFF
--- a/Blackmagic/DaVinciResolve16.munki.recipe
+++ b/Blackmagic/DaVinciResolve16.munki.recipe
@@ -45,7 +45,7 @@ this user's home will be used, and if run at the loginwindow, the root user's ho
             <key>display_name</key>
             <string>DaVinci Resolve 16</string>
             <key>minimum_os_version</key>
-            <string>10.12.6</string>
+            <string>10.14.6</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>uninstallable</key>


### PR DESCRIPTION
Minimum system requirements for macOS
- macOS 10.14.6 Mojave
- 16 GB of system memory is recommended and 32 GB is recommended minimum when using Fusion
- Blackmagic Design Desktop Video version 10.4.1 or later
- RED Rocket-X Driver 2.1.34.0 and Firmware 1.4.22.18 or later
- RED Rocket Driver 2.1.23.0 and Firmware 1.1.18.0 or later