### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/Datavyu/Datavyu.download.recipe
+++ b/Datavyu/Datavyu.download.recipe
@@ -39,7 +39,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/datavyu.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>identifier "org.datavyu" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = KUV653PA5T</string>
 			</dict>
 		</dict>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.