### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Datavyu/Datavyu.pkg.recipe
+++ b/Datavyu/Datavyu.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.asemak.recipes.pkg.datavyu</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.datavyu</string>
 		<key>NAME</key>
 		<string>datavyu</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ❌ Datavyu/Datavyu.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/asemak-recipes/Datavyu/Datavyu.pkg.recipe
Processing repos/asemak-recipes/Datavyu/Datavyu.pkg.recipe...
URLDownloader
{'Input': {'filename': 'datavyu.dmg',
           'url': 'http://www.datavyu.org/releases_pre/Datavyu-OSX-latest.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
Receipt written to ~/Library/AutoPkg/Cache/com.asemak.recipes.pkg.datavyu/receipts/Datavyu.pkg-receipt-20210213-211919.plist

The following recipes failed:
    repos/asemak-recipes/Datavyu/Datavyu.pkg.recipe
        Error in com.asemak.recipes.pkg.datavyu: Processor: URLDownloader: Error: Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'http://www.datavyu.org/releases_pre/Datavyu-OSX-latest.dmg', '--fail', '--output', '~/Library/AutoPkg/Cache/com.asemak.recipes.pkg.datavyu/downloads/tmp2r6gg6oi']' returned non-zero exit status 22.

Nothing downloaded, packaged or imported.
```

